### PR TITLE
Clipped jump2 ending - web audio fix

### DIFF
--- a/Assets/Audio/SFX/Jump2.wav
+++ b/Assets/Audio/SFX/Jump2.wav
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:556d86c7d4badb4b417dbc355c3cb6eeb77674772c565ea907f39118901b6a9e
-size 18674
+oid sha256:b691d1a70e0803bf840f00f67978874fffecaff8e29476437a29c6757c0e9eb4
+size 18450

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -820,7 +820,7 @@ PlayerSettings:
   webGLTemplate: PROJECT:JamTemplate
   webGLAnalyzeBuildSize: 0
   webGLUseEmbeddedResources: 0
-  webGLCompressionFormat: 0
+  webGLCompressionFormat: 1
   webGLWasmArithmeticExceptions: 0
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0


### PR DESCRIPTION
The jump sound effect was causing pop/clicks at the end of the click on web builds.  Likely related to FMOD processing and sound buffers.

Altering the jump2 clip to be shorter at the end seems to have fixed the issue.